### PR TITLE
Add to button patterns to include grey secondaries

### DIFF
--- a/_patterns/buttons/buttons.css
+++ b/_patterns/buttons/buttons.css
@@ -1,10 +1,23 @@
+/* These classes style the primary (white) icon states */
 .social-icon {
   color: var(--color-secondary-light);
 }
 
 .social-icon:hover,
 .social-icon:focus {
-  color: var(--color-secondary-dark);
+  outline: 3px solid var(--color-primary);
+  outline-offset: 3px;
+}
+
+/* These classes style the secondary (black) icon states */
+.social-icon-2 {
+  color: var(--color-primary);
+}
+
+.social-icon-2:hover,
+.social-icon-2:focus {
+  outline: 3px solid var(--color-primary);
+  outline-offset: 3px;
 }
 
 /* Use these classes for the color include to define button color*/
@@ -36,4 +49,18 @@
 .color-web {
   background-color: var(--color-web);
   border-color: var(--color-web);
+}
+
+/* These classes style the secondary portfolio and calendly buttons */
+.btn-2 {
+  color: var(--color-primary);
+  background-color: var(--color-secondary);
+  border-color: var(--color-secondary);
+}
+
+.btn-2:hover,
+.btn-2:focus {
+  color: var(--color-secondary);
+  background-color: var(--color-primary);
+  border-color: var(--color-primary);
 }

--- a/_patterns/buttons/calendly-2.html
+++ b/_patterns/buttons/calendly-2.html
@@ -1,0 +1,1 @@
+<a class="btn btn-2" href="https://calendly.com/{{include.student-username}}/{{include.meeting-length}}" aria_label="{{include.aria}}" tabindex="0">Book a Meeting</a>

--- a/_patterns/buttons/config.yml
+++ b/_patterns/buttons/config.yml
@@ -18,6 +18,18 @@ patterns:
       - name: aria
         type: string
         example: "This button links to this student's portfolio site"
+  portfolio-2:
+    title: "Portfolio Grey Button"
+    description: |
+      This button is used as a call-to-action to encourage site visitors to visit student's personal portfolio sites.
+    width: 10em
+    fields:
+      - name: portfolio-url
+        type: url
+        example: "#"
+      - name: aria
+        type: string
+        example: "This button links to this student's portfolio site"
   calendly:
     title: "Book With Calendly Button"
     description: |
@@ -36,10 +48,39 @@ patterns:
       - name: aria
         type: string
         example: "This button allows you to book a virtual meeting with this student"
-  icon:
-    title: "Clickable Icons"
+  calendly-2:
+    title: "Calendly Grey Button"
     description: |
-      These buttons are used to link to external site content, including student's social media accounts.
+      This button is used as a call-to-action to encourage site visitors to book a meeting with students.
+    width: 10em
+    fields:
+      - name: student-username
+        type: string
+        example: "bulk0002"
+      - name: meeting-length
+        type: string
+        example: "15min"
+      - name: aria
+        type: string
+        example: "This button allows you to book a virtual meeting with this student"
+  icon:
+    title: "Icons"
+    description: |
+      These white buttons are used to link to external site content, including student's social media accounts.
+    fields:
+      - name: url
+        type: url
+        example: "#"
+      - name: aria
+        type: string
+        example: "This button navigates you to this student's instagram account"
+      - name: id
+        type: string
+        example: "instagram"
+  icon-2:
+    title: "Secondary Icons"
+    description: |
+      These black buttons are used to link to external site content, including student's social media accounts.
     fields:
       - name: url
         type: url

--- a/_patterns/buttons/icon-2.html
+++ b/_patterns/buttons/icon-2.html
@@ -1,0 +1,8 @@
+<a class="social-icon-2" href="{{include.url}}" aria_label="{{include.aria}}">
+    <i class="icon i-32" id="{{include.id}}" tabindex="0">
+      <svg>
+        <use xlink:href="/images/icons.svg#{{include.id}}"></use>
+      </svg>
+    </i>
+</a>
+  

--- a/_patterns/buttons/portfolio-2.html
+++ b/_patterns/buttons/portfolio-2.html
@@ -1,0 +1,1 @@
+<a class="btn btn-2" href="{{include.portfolio-url}}" aria_label="{{include.aria}}" tabindex="0">My Portfolio</a>

--- a/css/theme.css
+++ b/css/theme.css
@@ -37,8 +37,8 @@ h6 {
 
 .btn:focus,
 .btn:hover {
-  background-color: var(--color-secondary-light);
-  border-color: var(--color-secondary-light);
+  background-color: var(--color-secondary);
+  border-color: var(--color-secondary);
   color: var(--color-primary);
   filter: drop-shadow(0 0.3em .5em #333132);
 }


### PR DESCRIPTION
The outline for hover/focus/tab states ideally should be rounded to match the branding guidelines, but the outline css property does not have a border radius.

I've added this to the to-do list, but it is a lower priority at the moment.