### PR TITLE
Removes calendly html file

### DIFF
--- a/calendly-about.html
+++ b/calendly-about.html
@@ -1,5 +1,0 @@
----
-layout: default
-description:
-highlight_nav:
----


### PR DESCRIPTION
The quiz.html file encompasses the function of this page, so it is no longer needed in the repository