### PR TITLE
Remove the excess css links in the default.html layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,8 +21,6 @@
   <meta name="twitter:site" content="@algonquindesign">
   <link rel="shortcut icon" href="favicon.ico">
   <link rel="icon" type="image/png" href="https://grads.images.algonquindesign.ca/2021/general/favicon-196.png">
-  <link href="css/modules.css" rel="stylesheet">
-  <link href="css/type.css" rel="stylesheet">
   <link href="css/main.css" rel="stylesheet">
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Barlow:ital,wght@0,400;0,700;1,400;1,700&family=Bungee&display=swap" rel="stylesheet">


### PR DESCRIPTION
Shouldn't affect site functionality, but @akhoinguyen noticed the unnecessary redundancies in the default layout, so this is to correct it.