### PR TITLE
Use strip to remove quote whitespace

### DIFF
--- a/_patterns/sections/layout1-work-section.html
+++ b/_patterns/sections/layout1-work-section.html
@@ -55,7 +55,7 @@
     </div>
 
     <blockquote class="quote-accent text-center">
-      <p class="mega layout1-student-quote">“{{include.data.quote_text}}”</p>
+      <p class="mega layout1-student-quote">“{{include.data.quote_text | strip}}”</p>
       {% if include.data.quote_author %}
         <footer><cite>{{include.data.quote_author}}</cite></footer>
       {% endif %}

--- a/_patterns/sections/template-2-work.html
+++ b/_patterns/sections/template-2-work.html
@@ -29,7 +29,7 @@
     </div>
 
     <blockquote class="quote-accent text-center">
-      <p class="mega t2-student-quote">“</span>{{include.data.quote_text}}”</p>
+      <p class="mega t2-student-quote">“</span>{{include.data.quote_text | strip}}”</p>
       {% if include.data.quote_author %}
         <footer><cite>{{include.data.quote_author}}</cite></footer>
       {% endif %}

--- a/_patterns/sections/template-3-intro-section.html
+++ b/_patterns/sections/template-3-intro-section.html
@@ -5,7 +5,7 @@
       </video>
     <h3 class="giga push-2">I am Generation <span>{{include.data.ation_word}}</span></h3>
     <blockquote class="quote-accent text-center">
-        <p class="mega">“{{include.data.quote_text}}”</p>
+        <p class="mega">“{{include.data.quote_text | strip}}”</p>
         {% if include.data.quote_author %}
             <footer><cite>{{include.data.quote_author}}</cite></footer>
         {% endif %}

--- a/_patterns/sections/template-4-section-2.html
+++ b/_patterns/sections/template-4-section-2.html
@@ -15,7 +15,7 @@
 
 <section class="pad-t pad-b gutter-2 wrapper push-2">
   <blockquote class="quote-accent text-center">
-    <p class="mega t4-student-quote">“{{include.data.quote_text}}”</p>
+    <p class="mega t4-student-quote">“{{include.data.quote_text | strip}}”</p>
     {% if include.data.quote_author %}
       <footer><cite>{{include.data.quote_author}}</cite></footer>
     {% endif %}

--- a/_patterns/sections/template-5-work.html
+++ b/_patterns/sections/template-5-work.html
@@ -43,7 +43,7 @@
 
     <div class="proj4-quote-section color-tint gutter-3-4 pad-t-2 pad-b-2">
       <blockquote class="quote-accent text-center">
-        <p class="mega t5-student-quote">“{{include.data.quote_text}}”</p>
+        <p class="mega t5-student-quote">“{{include.data.quote_text | strip}}”</p>
         {% if include.data.quote_author %}
           <footer><cite>{{include.data.quote_author}}</cite></footer>
         {% endif %}


### PR DESCRIPTION
Came from using the `|` paragraphs in the markdown files.

Just a small PR, but once it's submitted I can notify students who had concerns about their quotes that they have (at least mostly) been fixed.