### PR TITLE
Remove general image selector from CSS

### DIFF
--- a/_patterns/sections/sections.css
+++ b/_patterns/sections/sections.css
@@ -23,8 +23,7 @@ div.graduate-award-grid .rainbow-line {
 }
 
 /* Define general shape of images and videos, excluding the SVG rainbow line */
-img:not(.rainbow-line),
-img:not(.awarded-student > img) {
+img:not(.rainbow-line) {
   background-color: var(--color-secondary);
   border-radius: 10px;
 }


### PR DESCRIPTION
This looks to be a deprecated selector from building the awards page; removing it does not appear to cause any changes